### PR TITLE
Feature/ch17837/asset magic urls

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -141,7 +141,7 @@ callbacks=cb_,_cb
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/skipscale/config.py
+++ b/skipscale/config.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, List, Optional, Tuple, Union
 
 import schema
+import validators
 import toml
 
 config_path = os.getenv('SKIPSCALE_CONFIG', "config.toml")
@@ -19,6 +20,7 @@ tenant_overrideable_fields = {
     schema.Optional('cache_control_override'): str,
     schema.Optional('encryption'): encryption_fields,
     schema.Optional('origin'): str,
+    schema.Optional('proxy'): validators.url,
 }
 
 main_fields = {
@@ -136,4 +138,13 @@ class Config():
         return None
 
     def origin(self, tenant: str) -> Optional[str]:
+        """Returns a fixed origin for the tenant. If not set, the (encrypted)
+        path from the request is used."""
+
         return self._optional_main_optional_tenant(tenant, "origin")
+
+    def proxy(self, tenant: str) -> Optional[str]:
+        """Returns an URL to a tenant-specific HTTP proxy if set. The
+        URL can include basic auth credentials for the proxy."""
+
+        return self._optional_main_optional_tenant(tenant, "proxy")

--- a/skipscale/original.py
+++ b/skipscale/original.py
@@ -33,6 +33,7 @@ async def original(request):
     output_headers = cache_headers(request.app.state.config.cache_control_override(tenant), r)
     if 'content-type' in r.headers:
         output_headers['content-type'] = r.headers['content-type']
-    if 'content-length' in r.headers:
-        output_headers['content-length'] = r.headers['content-length']
+    # Since we're not streaming we know the real length. Upstream content-length may include
+    # content-encoding, which is reversed by httpx.
+    output_headers['content-length'] = str(len(r.content))
     return Response(r.content, status_code=r.status_code, headers=output_headers)

--- a/skipscale/original.py
+++ b/skipscale/original.py
@@ -11,8 +11,9 @@ async def original(request):
 
     tenant = request.path_params['tenant']
     image_uri = request.path_params['image_uri']
+    config = request.app.state.config
 
-    origin = request.app.state.config.origin(tenant)
+    origin = config.origin(tenant)
     if origin:
         request_url = origin + image_uri
     else:
@@ -22,13 +23,13 @@ async def original(request):
             request_url = decrypt_url(key, tenant, image_uri.split('.')[0]) # omit file extension from encrypted url
         except:
             raise HTTPException(400)
-    
+
     span = Hub.current.scope.span
     if span is not None:
         span.set_tag("tenant", tenant)
         span.set_tag("origin_url", request_url)
 
-    r = await make_request(request, request_url)
+    r = await make_request(request, request_url, proxy=config.proxy(tenant))
     output_headers = cache_headers(request.app.state.config.cache_control_override(tenant), r)
     if 'content-type' in r.headers:
         output_headers['content-type'] = r.headers['content-type']


### PR DESCRIPTION
Adds support for routing upstream requests through a proxy on a per-tenant basis. Example configuration entry for a tenant called `proxy-example`:
```
[tenants.proxy-example]
proxy = "http://user:pass@my-proxy.example.com:8888/"
```

Also fixes setting Content-Length when origin uses Content-Encoding.