### PR TITLE
Separate asset prefix support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -26,8 +26,10 @@ key = "01234567890123456789012345678901" # 32 hex digits (128 bits)
 username = "admin" # these credentials are for the endpoint used to encrypt URLs
 password = "admin"
 url_prefix = "https://images.example.com/images/v1/" # the canonical prefix added to encrypted urls. Must end in /.
+# asset_url_prefix = "https://assets.example.com/assets/v1/" # the canonical prefix added to encrypted asset urls. Defaults to url_prefix.
 
 [tenants.cover-images]
 origin = "https://storage.example.com/cover-originals/"
 default_quality = 90
 max_pixel_ratio = 3
+# proxy = "http://user:pass@my-proxy.example.com:8888/" # if set, uses an upstream proxy for this tenant

--- a/skipscale/encrypt.py
+++ b/skipscale/encrypt.py
@@ -8,6 +8,7 @@ from starlette.responses import JSONResponse
 import validators
 
 from skipscale.urlcrypto import encrypt_url
+from skipscale.config import Config
 
 log = logging.getLogger(__name__)
 post_schema = Schema({
@@ -52,8 +53,9 @@ async def encrypt(request):
     if not key:
         raise HTTPException(400, detail='Missing configuration')
 
-    image_prefix = request.app.state.config.encryption_url_prefix(tenant) + tenant + '/'
-    asset_prefix = request.app.state.config.encryption_url_prefix(tenant) + 'asset/' + tenant + '/'
+    config: Config = request.app.state.config
+    image_prefix = config.encryption_url_prefix(tenant) + tenant + '/'
+    asset_prefix = config.encryption_asset_url_prefix(tenant) + 'asset/' + tenant + '/'
     result = {}
 
     def array_to_result(prefix, orig_urls) -> None:


### PR DESCRIPTION
Adds a config option for a separate prefix for asset URLs. Useful if these need special treament in the front-end cache.