### PR TITLE
RGBA and master format support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -33,5 +33,5 @@ origin = "https://storage.example.com/cover-originals/"
 default_quality = 90
 max_pixel_ratio = 3
 # proxy = "http://user:pass@my-proxy.example.com:8888/" # if set, uses an upstream proxy for this tenant
-# default_format = "jpeg" # if set, images are converted to this format by default
+# default_format = "jpeg" # if set, images are converted to this format by default when scaling is requested
 # force_allow_cors = true # if set, allow CORS requests regardless of origin ACAO

--- a/skipscale/planner.py
+++ b/skipscale/planner.py
@@ -41,7 +41,7 @@ async def planner(request):
         del q['width']
     if 'height' in q and q['height'] == 0:
         del q['height']
-    
+
     if ('center-x' in q and 'center-y' not in q) or ('center-y' in q and 'center-x' not in q):
         raise HTTPException(400, "both center-x and center-y required")
 

--- a/skipscale/planner_math.py
+++ b/skipscale/planner_math.py
@@ -82,12 +82,12 @@ def plan_scale(query, imageinfo, max_pixel_ratio=None):
             dpr = query['dpr']
     else:
         dpr = 1
-     
+
     if 'width' in query:
         width = query['width'] * dpr
     else:
         width = 0
-    
+
     if 'height' in query:
         height = query['height'] * dpr
     else:


### PR DESCRIPTION
Adds support for converting RGBA images to JPEG (images are composited onto a white background).

Also limits the action of `default_format` to cases when scaling is requested. This allows getting original quality image when no manipulation is desired.