### PR TITLE
CORS and revalidation improvements

### DIFF
--- a/skipscale/config.py
+++ b/skipscale/config.py
@@ -147,9 +147,10 @@ class Config():
         sent or it has a shorter max-age or s-maxage than the ones specified here.
 
         If stale-while-revalidate or stale-if-error are set here, they will be
-        also be merged into the upstrem header.
+        also be merged into the upstream header.
 
-        Note: upstream Expires and Pragma headers will be always be ignored."""
+        Note: upstream Expires and Pragma headers will be always be ignored
+        if this option is set."""
         return self._optional_main_optional_tenant(tenant, "cache_control_minimum")
 
     def max_pixel_ratio(self, tenant: str) -> int:

--- a/skipscale/config.py
+++ b/skipscale/config.py
@@ -25,6 +25,7 @@ tenant_overrideable_fields = {
                                                   lambda s: s in ('jpeg', 'png', 'webp')),
     schema.Optional('max_pixel_ratio'): int,
     schema.Optional('cache_control_override'): str,
+    schema.Optional('cache_control_minimum'): str,
     schema.Optional('encryption'): encryption_fields,
     schema.Optional('origin'): str,
     schema.Optional('proxy'): validators.url,
@@ -64,10 +65,11 @@ class Config():
     def _optional_main_optional_tenant(self, tenant: str, key: str) -> Any:
         if tenant in self.validated_config["tenants"] and key in self.validated_config["tenants"][tenant]:
             return self.validated_config["tenants"][tenant][key]
-        elif key in self.validated_config:
+
+        if key in self.validated_config:
             return self.validated_config[key]
-        else:
-            return None
+
+        return None
 
     def app_path_prefixes(self) -> List[str]:
         if "app_path_prefixes" in self.validated_config:
@@ -136,8 +138,19 @@ class Config():
             return None
         return default_format
 
-    def cache_control_override(self, tenant: str) -> int:
+    def cache_control_override(self, tenant: str) -> Optional[str]:
+        """Unconditionally overrides origin Cache-Control."""
         return self._optional_main_optional_tenant(tenant, "cache_control_override")
+
+    def cache_control_minimum(self, tenant: str) -> Optional[str]:
+        """Overrides origin Cache-Control cache times if either no Cache-Control is
+        sent or it has a shorter max-age or s-maxage than the ones specified here.
+
+        If stale-while-revalidate or stale-if-error are set here, they will be
+        also be merged into the upstrem header.
+
+        Note: upstream Expires and Pragma headers will be always be ignored."""
+        return self._optional_main_optional_tenant(tenant, "cache_control_minimum")
 
     def max_pixel_ratio(self, tenant: str) -> int:
         return self._optional_main_optional_tenant(tenant, "max_pixel_ratio")

--- a/skipscale/imageinfo.py
+++ b/skipscale/imageinfo.py
@@ -33,7 +33,7 @@ async def imageinfo(request):
 
     r = await make_request(request, request_url)
     # Technically imageinfo is ever only called internally so it doesn't need CORS headers to
-    # function.. But the planner will set up headers for its user-facing 304/307 responses based on
+    # function... but the planner will set up headers for its user-facing 304/307 responses based on
     # the headers it receives from imageinfo, so we need to pass them through for its benefit here.
     output_headers = cache_headers_with_config(config, tenant, r)
 

--- a/skipscale/imageinfo.py
+++ b/skipscale/imageinfo.py
@@ -4,7 +4,8 @@ from PIL import Image
 from starlette.responses import Response, JSONResponse
 
 from skipscale.exif_transpose import image_transpose_exif
-from skipscale.utils import cache_url, cache_headers_with_config, make_request
+from skipscale.utils import cache_url, cache_headers_with_config, make_request, \
+    extract_forwardable_params
 from skipscale.config import Config
 
 from sentry_sdk import Hub
@@ -20,12 +21,14 @@ async def imageinfo(request):
     if span is not None:
         span.set_tag("tenant", tenant)
 
+    _, fwd_q = extract_forwardable_params(dict(request.query_params))
     request_url = cache_url(
         request.app.state.config.cache_endpoint(),
         request.app.state.config.app_path_prefixes(),
         "original",
         tenant,
-        image_uri
+        image_uri,
+        fwd_q
     )
 
     r = await make_request(request, request_url)

--- a/skipscale/imageinfo.py
+++ b/skipscale/imageinfo.py
@@ -4,7 +4,7 @@ from PIL import Image
 from starlette.responses import Response, JSONResponse
 
 from skipscale.exif_transpose import image_transpose_exif
-from skipscale.utils import cache_url, cache_headers, make_request, should_allow_cors
+from skipscale.utils import cache_url, cache_headers_with_config, make_request
 from skipscale.config import Config
 
 from sentry_sdk import Hub
@@ -32,10 +32,7 @@ async def imageinfo(request):
     # Technically imageinfo is ever only called internally so it doesn't need CORS headers to
     # function.. But the planner will set up headers for its user-facing 304/307 responses based on
     # the headers it receives from imageinfo, so we need to pass them through for its benefit here.
-    output_headers = cache_headers(config.cache_control_override(tenant),
-                                   config.cache_control_minimum(tenant),
-                                   r,
-                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
+    output_headers = cache_headers_with_config(config, tenant, r)
 
     if r.status_code == 304:
         return Response(status_code=304, headers=output_headers)

--- a/skipscale/imageinfo.py
+++ b/skipscale/imageinfo.py
@@ -4,7 +4,8 @@ from PIL import Image
 from starlette.responses import Response, JSONResponse
 
 from skipscale.exif_transpose import image_transpose_exif
-from skipscale.utils import cache_url, cache_headers, make_request
+from skipscale.utils import cache_url, cache_headers, make_request, should_allow_cors
+from skipscale.config import Config
 
 from sentry_sdk import Hub
 
@@ -13,6 +14,7 @@ async def imageinfo(request):
 
     tenant = request.path_params['tenant']
     image_uri = request.path_params['image_uri']
+    config: Config = request.app.state.config
 
     span = Hub.current.scope.span
     if span is not None:
@@ -27,12 +29,22 @@ async def imageinfo(request):
     )
 
     r = await make_request(request, request_url)
-    output_headers = cache_headers(request.app.state.config.cache_control_override(tenant), r)
+    # Technically imageinfo is ever only called internally so it doesn't need CORS headers to
+    # function.. But the planner will set up headers for its user-facing 304/307 responses based on
+    # the headers it receives from imageinfo, so we need to pass them through for its benefit here.
+    output_headers = cache_headers(config.cache_control_override(tenant),
+                                   config.cache_control_minimum(tenant),
+                                   r,
+                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
 
     if r.status_code == 304:
         return Response(status_code=304, headers=output_headers)
-    
+
     i = Image.open(BytesIO(r.content))
     original_format = i.format
     i = image_transpose_exif(i)
-    return JSONResponse({'width': i.width, 'height': i.height, 'format': original_format.lower(), 'bytes': len(r.content)}, headers=output_headers)
+    return JSONResponse({'width': i.width,
+                         'height': i.height,
+                         'format': original_format.lower(),
+                         'bytes': len(r.content)},
+                        headers=output_headers)

--- a/skipscale/imageinfo.py
+++ b/skipscale/imageinfo.py
@@ -17,7 +17,7 @@ async def imageinfo(request):
     span = Hub.current.scope.span
     if span is not None:
         span.set_tag("tenant", tenant)
-        
+
     request_url = cache_url(
         request.app.state.config.cache_endpoint(),
         request.app.state.config.app_path_prefixes(),

--- a/skipscale/main.py
+++ b/skipscale/main.py
@@ -41,9 +41,9 @@ def monkeypatch_pil():
 
 routes = [
     # Used for original images
-    Route('/original/{tenant}/{image_uri:path}', original),
+    Route('/original/{tenant}/{image_uri:path}', original, methods=['GET', 'OPTIONS']),
     # Used for reverse-proxying non-image assets
-    Route('/asset/{tenant}/{image_uri:path}', original),
+    Route('/asset/{tenant}/{image_uri:path}', original, methods=['GET', 'OPTIONS']),
 
     Route('/imageinfo/{tenant}/{image_uri:path}', imageinfo),
     Route('/scale/{tenant}/{image_uri:path}', scale),

--- a/skipscale/original.py
+++ b/skipscale/original.py
@@ -43,7 +43,7 @@ async def original(request):
 
     r = await make_request(request, request_url, proxy=config.proxy(tenant))
     output_headers = cache_headers(config.cache_control_override(tenant), r,
-                                   allow_cors=should_allow_cors(request, config.allow_cors(tenant)))
+                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
     if 'content-type' in r.headers:
         output_headers['content-type'] = r.headers['content-type']
     # Since we're not streaming we know the real length.

--- a/skipscale/original.py
+++ b/skipscale/original.py
@@ -28,6 +28,13 @@ async def original(request):
     origin = config.origin(tenant)
     if origin:
         request_url = origin + image_uri
+        # Encrypted URLs allow passing query parameters to the origin (as they are wrapped in the
+        # encrypted envelope).  Also allow this for fixed-origin requests by forwarding the query
+        # string attached to the request.
+        original_qp = request.url.query
+        if original_qp:
+            request_url = '{request_url}?{original_qp}'
+            log.debug('preserving query params for fixed-origin request: %s', request_url)
     else:
         # If no origin is specified for the tenant, we expect encrypted urls.
         key = config.encryption_key(tenant)

--- a/skipscale/original.py
+++ b/skipscale/original.py
@@ -47,7 +47,9 @@ async def original(request):
         log.debug('forwarding %s request to %s', request.method, request_url)
 
     r = await make_request(request, request_url, proxy=config.proxy(tenant), method=method)
-    output_headers = cache_headers(config.cache_control_override(tenant), r,
+    output_headers = cache_headers(config.cache_control_override(tenant),
+                                   config.cache_control_minimum(tenant),
+                                   r,
                                    allow_cors=should_allow_cors(config.allow_cors(tenant), r))
     if 'content-type' in r.headers:
         output_headers['content-type'] = r.headers['content-type']

--- a/skipscale/original.py
+++ b/skipscale/original.py
@@ -2,7 +2,7 @@ from starlette.exceptions import HTTPException
 from starlette.responses import Response
 
 from skipscale.urlcrypto import decrypt_url
-from skipscale.utils import cache_headers, make_request, should_allow_cors, get_logger
+from skipscale.utils import cache_headers_with_config, make_request, get_logger
 from skipscale.config import Config
 
 from sentry_sdk import Hub
@@ -47,10 +47,8 @@ async def original(request):
         log.debug('forwarding %s request to %s', request.method, request_url)
 
     r = await make_request(request, request_url, proxy=config.proxy(tenant), method=method)
-    output_headers = cache_headers(config.cache_control_override(tenant),
-                                   config.cache_control_minimum(tenant),
-                                   r,
-                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
+    output_headers = cache_headers_with_config(config, tenant, r)
+
     if 'content-type' in r.headers:
         output_headers['content-type'] = r.headers['content-type']
     # Since we're not streaming we know the real length.

--- a/skipscale/planner.py
+++ b/skipscale/planner.py
@@ -3,7 +3,7 @@ from starlette.exceptions import HTTPException
 from starlette.responses import Response, RedirectResponse
 
 from skipscale.planner_math import plan_scale
-from skipscale.utils import cache_url, cache_headers, make_request, get_logger
+from skipscale.utils import cache_url, cache_headers, make_request, get_logger, should_allow_cors
 from skipscale.config import Config
 
 from sentry_sdk import Hub
@@ -66,7 +66,10 @@ async def planner(request):
         image_uri
     )
     r = await make_request(request, imageinfo_url)
-    output_headers = cache_headers(config.cache_control_override(tenant), r)
+    output_headers = cache_headers(config.cache_control_override(tenant),
+                                   config.cache_control_minimum(tenant),
+                                   r,
+                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
 
     if r.status_code == 304:
         return Response(status_code=304, headers=output_headers)

--- a/skipscale/planner.py
+++ b/skipscale/planner.py
@@ -3,7 +3,7 @@ from starlette.exceptions import HTTPException
 from starlette.responses import Response, RedirectResponse
 
 from skipscale.planner_math import plan_scale
-from skipscale.utils import cache_url, cache_headers, make_request, get_logger, should_allow_cors
+from skipscale.utils import cache_url, cache_headers_with_config, make_request, get_logger
 from skipscale.config import Config
 
 from sentry_sdk import Hub
@@ -66,10 +66,7 @@ async def planner(request):
         image_uri
     )
     r = await make_request(request, imageinfo_url)
-    output_headers = cache_headers(config.cache_control_override(tenant),
-                                   config.cache_control_minimum(tenant),
-                                   r,
-                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
+    output_headers = cache_headers_with_config(config, tenant, r)
 
     if r.status_code == 304:
         return Response(status_code=304, headers=output_headers)

--- a/skipscale/scale.py
+++ b/skipscale/scale.py
@@ -98,7 +98,7 @@ async def scale(request):
 
     r = await make_request(request, request_url)
     output_headers = cache_headers(config.cache_control_override(tenant), r,
-                                   allow_cors=should_allow_cors(request, config.allow_cors(tenant)))
+                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
 
     if r.status_code == 304:
         return Response(status_code=304, headers=output_headers)

--- a/skipscale/scale.py
+++ b/skipscale/scale.py
@@ -9,7 +9,7 @@ from starlette.exceptions import HTTPException
 from starlette.responses import Response, StreamingResponse
 
 from skipscale.exif_transpose import image_transpose_exif
-from skipscale.utils import cache_url, cache_headers, make_request, should_allow_cors, \
+from skipscale.utils import cache_url, cache_headers_with_config, make_request, \
     get_logger
 from skipscale.config import Config
 
@@ -97,10 +97,7 @@ async def scale(request):
     )
 
     r = await make_request(request, request_url)
-    output_headers = cache_headers(config.cache_control_override(tenant),
-                                   config.cache_control_minimum(tenant),
-                                   r,
-                                   allow_cors=should_allow_cors(config.allow_cors(tenant), r))
+    output_headers = cache_headers_with_config(config, tenant, r)
 
     if r.status_code == 304:
         return Response(status_code=304, headers=output_headers)

--- a/skipscale/scale.py
+++ b/skipscale/scale.py
@@ -97,7 +97,9 @@ async def scale(request):
     )
 
     r = await make_request(request, request_url)
-    output_headers = cache_headers(config.cache_control_override(tenant), r,
+    output_headers = cache_headers(config.cache_control_override(tenant),
+                                   config.cache_control_minimum(tenant),
+                                   r,
                                    allow_cors=should_allow_cors(config.allow_cors(tenant), r))
 
     if r.status_code == 304:

--- a/skipscale/scale.py
+++ b/skipscale/scale.py
@@ -10,7 +10,7 @@ from starlette.responses import Response, StreamingResponse
 
 from skipscale.exif_transpose import image_transpose_exif
 from skipscale.utils import cache_url, cache_headers_with_config, make_request, \
-    get_logger
+    get_logger, extract_forwardable_params
 from skipscale.config import Config
 
 from sentry_sdk import Hub
@@ -78,8 +78,9 @@ async def scale(request):
     if span is not None:
         span.set_tag("tenant", tenant)
 
+    in_q, fwd_q = extract_forwardable_params(dict(request.query_params))
     try:
-        q = query_schema.validate(dict(request.query_params))
+        q = query_schema.validate(in_q)
     except Exception:
         log.exception('invalid query parameters (scale) for %s: %s', request.path_params,
                       request.query_params)
@@ -93,7 +94,8 @@ async def scale(request):
         config.app_path_prefixes(),
         "original",
         tenant,
-        image_uri
+        image_uri,
+        fwd_q
     )
 
     r = await make_request(request, request_url)

--- a/skipscale/utils.py
+++ b/skipscale/utils.py
@@ -95,7 +95,10 @@ def cache_headers(cache_control_override: Optional[str],
             output_headers.update(allow_cors)
         else:
             output_headers['access-control-allow-origin'] = '*'
-        output_headers['vary'] = 'origin'
+        final_acao = output_headers.get('access-control-allow-origin')
+        # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching
+        if final_acao and final_acao != '*':
+            output_headers['vary'] = 'origin'
     return output_headers
 
 def should_allow_cors(force_flag: bool, upstream_response) -> Union[dict, bool]:

--- a/skipscale/utils.py
+++ b/skipscale/utils.py
@@ -1,3 +1,5 @@
+"""Miscellaneous utility functions."""
+
 import logging
 from urllib.parse import urljoin, urlencode
 from typing import Optional, Union
@@ -28,6 +30,9 @@ async def make_request(incoming_request, outgoing_request_url,
         outgoing_request_headers['if-modified-since'] = incoming_request.headers['if-modified-since']
     if 'if-none-match' in incoming_request.headers:
         outgoing_request_headers['if-none-match'] = incoming_request.headers['if-none-match']
+    if 'origin' in incoming_request.headers:
+        outgoing_request_headers['origin'] = incoming_request.headers['origin']
+        log.debug('forwarding downstream Origin: %s', outgoing_request_headers['origin'])
 
     close_client = False
     client = incoming_request.app.state.httpx_client
@@ -78,10 +83,18 @@ def cache_headers(cache_control_override, received_response,
         output_headers['vary'] = 'origin'
     return output_headers
 
-def should_allow_cors(request, force_flag: bool):
-    # TODO: ACAO is forced unconditionally until Varnish issues can be resolved
-    #if 'origin' in request.headers and force_flag:
+def should_allow_cors(force_flag: bool, upstream_response) -> Union[str, bool]:
+    log = get_logger('utils', 'should_allow_cors')
+
+    # If force is set in configuration, always return ACAO=*
     if force_flag:
+        log.debug('forcing ACAO')
         return True
+
+    # Check if upstream returned ACAO and pass it on if it did
+    if upstream_response is not None and 'access-control-allow-origin' in upstream_response.headers:
+        acao = upstream_response.headers['access-control-allow-origin']
+        log.debug('forwarding upstream ACAO: %s', acao)
+        return acao
 
     return False

--- a/skipscale/utils.py
+++ b/skipscale/utils.py
@@ -138,8 +138,8 @@ def should_allow_cors(force_flag: bool, upstream_response) -> Union[dict, bool]:
     return False
 
 def is_safe_path(path: str) -> bool:
-    """Returns a path with traversal and double slashed eliminated. Leading slashes are also
-    removed."""
+    """Checks whether the given path attempts traversal with /. Returns True
+    if path is safe, False otherwise."""
 
     is_safe = True
     new_comps: List[str] = []

--- a/skipscale/utils.py
+++ b/skipscale/utils.py
@@ -159,6 +159,27 @@ def is_safe_path(path: str) -> bool:
 
     return is_safe
 
+# This should contain parameters that typically indicate the version of a mutable
+# resource. This allows scaling efficiently caching paths such as /foo.jpg?v=ab1234
+# where contents of foo.jpg may change but the change will be reflected by a changed
+# query string in some container. These parameters must not overlap with scaling-related
+# parameters.
+FORWARDABLE_PARAMS = ('v', 'hash')
+
+def extract_forwardable_params(q_params: Dict[str, str]) -> Tuple[Dict[str, str], Dict[str, str]]:
+    """Extract parameters that should be forwarded to subsequent requests
+    or the origin from a query string. Modifies the dictionary passed in,
+    returns the extracted parameters as a new dictionary."""
+
+    result: Dict[str, str] = {}
+    for key in FORWARDABLE_PARAMS:
+        try:
+            result[key] = q_params.pop(key)
+        except KeyError:
+            pass
+
+    return q_params, result
+
 class ParsedCacheControl:
     """A parsed representation of a Cache-Control header."""
 

--- a/skipscale/utils.py
+++ b/skipscale/utils.py
@@ -21,7 +21,7 @@ def cache_url(cache_endpoint, app_path_prefixes, url_type, tenant, image_uri, pa
     return url
 
 async def make_request(incoming_request, outgoing_request_url,
-                       stream=False,
+                       stream=False, method='GET',
                        proxy: Optional[str] = None):
     log = get_logger('utils', 'make_request')
 
@@ -45,7 +45,7 @@ async def make_request(incoming_request, outgoing_request_url,
         client = AsyncClient(timeout=client.timeout, proxies=proxy)
         log.debug('fetching %s through proxy', outgoing_request_url)
 
-    req = client.build_request("GET", outgoing_request_url, headers=outgoing_request_headers)
+    req = client.build_request(method, outgoing_request_url, headers=outgoing_request_headers)
     try:
         r = await client.send(req, stream=stream)
     except RequestError:


### PR DESCRIPTION
CORS improvements:
  * All endpoints now consistently forward CORS-related headers. This should fix issues with caches randomly caching wrong headers.
  * CORS support is more complete.

Caching/revalidation improvements:
  * Minimum `Cache-Control` caching times can now be configured instead of an unconditional override.
  * Versioning-related query parameters are passed to sub-requests from the planner to properly cache mutable paths with versioning hints.

Other fixes:
  * `/original` (and `/assets`) will forward HEAD requests as HEAD, avoiding wasting time with a GET to upstream.
  * `/original` no longer allows path traversal past a fixed origin.
  * Query parameters to `/original` with a fixed origin are now forwarded (similar parameters embedded in crypto-URLs).