### PR TITLE
Dockerfile: Install pip dependencies before adding the application code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,14 @@ RUN set -ex && mkdir /app
 WORKDIR /app
 
 # -- Adding Pipfiles
-COPY . .
+COPY Pipfile .
+COPY Pipfile.lock .
 
 # -- Install dependencies:
 RUN set -ex && CC="$CC" LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" pipenv install --deploy --system
+
+# -- Add the application
+COPY . .
 
 EXPOSE 8000
 CMD exec gunicorn skipscale.main:app --bind $BIND_ADDR --workers $WORKER_PROCESSES --worker-class uvicorn.workers.UvicornWorker


### PR DESCRIPTION
Install pip dependencies before adding the application code, so the dependencies will not be rebuilt when application code changes. This appears to be already suggested in comments in Dockerfile.