### PR TITLE
Fix GIF/PNG re-encode prevention when default_format is set

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,9 +11,6 @@ black = "*"
 types-toml = "*"
 
 [packages]
-pillow-simd = {version = "*", platform_machine = "== 'x86_64'"}
-pillow = {version = "*", platform_machine = "!= 'x86_64'"}
-httpx = {extras = ["http2"], version = "*"}
 pycryptodomex = "*"
 starlette = "*"
 uvicorn = "*"
@@ -23,6 +20,9 @@ gunicorn = "*"
 validators = "*"
 sentry-sdk = "*"
 httptools = "*"
+pillow-simd = {version = "*", platform_machine = "== 'x86_64'"}
+pillow = {version = "*", platform_machine = "!= 'x86_64'"}
+httpx = {extras = [ "http2",], version = "*"}
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "30d4abbc7a9c1e6ccd5f86cf0f0cb3e0231843b685443344feffaffe7c7b1d32"
+            "sha256": "4b03da1a1ec33ae4d9ef6002748f0bafa695c35c3f8cc5b4ab5fd330fc603897"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,6 +27,8 @@
         "certifi": {
             "hashes": [
                 "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
                 "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
             "markers": "python_version >= '3.6'",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b03da1a1ec33ae4d9ef6002748f0bafa695c35c3f8cc5b4ab5fd330fc603897"
+            "sha256": "30d4abbc7a9c1e6ccd5f86cf0f0cb3e0231843b685443344feffaffe7c7b1d32"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,7 +30,7 @@
                 "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
+            "version": "==2022.12.7"
         },
         "click": {
             "hashes": [
@@ -53,7 +53,7 @@
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
                 "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==5.1.1"
         },
         "gunicorn": {
@@ -166,7 +166,7 @@
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
                 "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
         "pillow": {
@@ -419,8 +419,16 @@
                 "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
                 "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==0.3.6"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+                "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.0"
         },
         "iniconfig": {
             "hashes": [
@@ -576,7 +584,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "tomlkit": {


### PR DESCRIPTION
Usually GIF/PNG are not scaled/re-encoded unless a format conversion was explicitly requested to preserve animations and prevent artifacts in graphics. If `default_format` was set in configuration, these would in some circumstances get re-encoded anyway.

This fixed the logic and applies Dependabot suggestions.