### PR TITLE
Feature/allow force default format

### DIFF
--- a/skipscale/config.py
+++ b/skipscale/config.py
@@ -23,6 +23,7 @@ tenant_overrideable_fields = {
     schema.Optional("default_format"): schema.And(
         str, schema.Use(str.lower), lambda s: s in ("jpeg", "png", "webp")
     ),
+    schema.Optional("force_default_format"): bool,
     schema.Optional("max_pixel_ratio"): int,
     schema.Optional("cache_control_override"): str,
     schema.Optional("cache_control_minimum"): str,
@@ -225,6 +226,18 @@ class Config:
         Defaults to False."""
 
         result = self._optional_main_optional_tenant(tenant, "force_allow_cors")
+        if result is None:
+            result = False
+
+        return result
+
+    def force_default_format(self, tenant: str) -> bool:
+        """Returns True if default_format should be applied even to image formats
+        such as PNG/GIF that are otherwise expected to contain graphics/animations.
+
+        Defaults to False."""
+
+        result = self._optional_main_optional_tenant(tenant, "force_default_format")
         if result is None:
             result = False
 

--- a/skipscale/planner.py
+++ b/skipscale/planner.py
@@ -180,11 +180,13 @@ async def planner(request: Request):
         quality = config.default_quality(tenant)
 
     default_format = config.default_format(tenant)
+    force_default = config.force_default_format(tenant)
     is_nonscaled_source = imageinfo['format'] in NONSCALED_FORMATS
 
     if "format" in q:
         format = q["format"]
-    elif default_format and not size_identical and not is_nonscaled_source:
+    elif default_format and not size_identical and \
+         (not is_nonscaled_source or force_default):
         # Convert to default format if scaling, otherwise
         # allow grabbing the original size & format.
         #
@@ -192,6 +194,8 @@ async def planner(request: Request):
         # and an explicit target format is _not_ requested, then don't switch
         # format to default. This prevents mangling graphics PNGs And
         # animated GIFs if default_format is set.
+        log.debug('applying default format %s→%s (is_nonscaled_source=%s force_default=%s)',
+                  imageinfo['format'], default_format, is_nonscaled_source, force_default)
         format = default_format
     else:
         format = imageinfo["format"]

--- a/skipscale/utils.py
+++ b/skipscale/utils.py
@@ -156,7 +156,6 @@ def should_allow_cors(force_flag: bool, upstream_response) -> Union[dict, bool]:
 
     # If force is set in configuration, always return ACAO=*
     if force_flag:
-        log.debug("forcing ACAO")
         return True
 
     # Check if upstream returned ACAO and pass it on if it did


### PR DESCRIPTION
Adds a new tenant config boolean option `force_default_format`, which will cause the `default_format` setting to be applied to all image formats.